### PR TITLE
fix memory leak

### DIFF
--- a/src/hvpp/hvpp/ia32/win32/memory.cpp
+++ b/src/hvpp/hvpp/ia32/win32/memory.cpp
@@ -47,5 +47,7 @@ namespace ia32::detail
 
       range_list[count] = memory_range(address, address + size);
     } while (++count < range_list_size);
+	
+    ExFreePool(physical_memory_ranges);
   }
 }


### PR DESCRIPTION
since MmGetPhysicalMemoryRanges is not documented, the fact that it allocates memory that you're supposed to free is also not documented.